### PR TITLE
fix: memory leak, HTTP body mismatch metric, and configurable DNS tim…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,75 @@
+## kconmon-ng v1.1.0
+
+### Bug Fixes
+
+- **MTR memory leak** — `lastRun` map in `MTRChecker` could grow unboundedly in long-running agents
+  on large clusters where node pairs come and go. Expired entries are now purged inline on each
+  `TryAcquire` call while the lock is already held, keeping the map size proportional to active
+  pairs within the current cooldown window.
+
+- **HTTP body pattern mismatch counted as success** — when a `bodyPattern` check failed, the
+  checker set `StatusCode = -1`, which was not caught by the result handler's `>= 400` guard and
+  was silently recorded as `result="success"` in Prometheus. The status code field now always
+  carries the real HTTP status. A dedicated `BodyMismatch bool` field signals pattern failure, and
+  the result handler correctly marks such checks as `result="fail"`.
+
+### Improvements
+
+- **Configurable DNS resolver dial timeout** — the dialer timeout for custom DNS resolvers was
+  previously hard-coded to 5 seconds and could not be adjusted for slow or distant resolvers.
+  A new `timeout` field has been added to the DNS checker config (default: `5s`). Update your
+  Helm values or config file to override:
+  ```yaml
+  checkers:
+    dns:
+      timeout: 3s
+  ```
+
+- **Jitter in agent re-registration backoff** — when the controller restarts, all agents
+  previously retried at exactly the same interval, causing a thundering herd. Up to 25% random
+  jitter is now added to each retry wait, spreading reconnect load across agents.
+
+- **MTR buffer allocation** — the 1500-byte read buffer in the traceroute loop was allocated
+  once per hop. It is now allocated once per trace, reducing GC pressure under frequent MTR runs.
+
+### Helm Chart
+
+- `config.checkers.dns.timeout` added to `values.yaml` (default: `5s`).
+
+### Tests
+
+- Updated `TestHTTPCheckerBodyPatternMismatch`: verifies `BodyMismatch=true` and real HTTP status
+  code instead of the former `-1` sentinel.
+- Added `TestHTTPCheckerBodyPatternMatch`: verifies `BodyMismatch=false` on a successful pattern.
+- Added `TestDNSCheckerTimeoutPropagated`: verifies the configured timeout is stored on the checker.
+- Added `TestMTRCheckerExpiredEntriesPurged`: verifies stale entries are removed from `lastRun`
+  after cooldown expiry.
+
+### Upgrade Notes
+
+The `HTTPDetails.StatusCode` field no longer returns `-1` for body pattern mismatches — it now
+always holds the actual HTTP response status code. If you have alerting or dashboards that rely
+on `statusCode == -1` to detect body mismatch failures, update them to use the new
+`bodyMismatch` field in the JSON result or the `result="fail"` label in Prometheus metrics.
+
+### Install
+
+```bash
+helm upgrade --install kconmon-ng oci://ghcr.io/esdmitrii/charts/kconmon-ng \
+  --version 1.1.0 \
+  --namespace kconmon-ng \
+  --create-namespace
+```
+
+### Images
+
+```
+ghcr.io/esdmitrii/kconmon-ng-agent:1.1.0
+ghcr.io/esdmitrii/kconmon-ng-controller:1.1.0
+```
+
+---
+
 ## kconmon-ng v1.0.0 — Initial Release
 
 Kubernetes Node Connectivity Monitor, next-generation rewrite with a gRPC-based agent/controller architecture and rich observability out of the box.

--- a/charts/kconmon-ng/Chart.yaml
+++ b/charts/kconmon-ng/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: kconmon-ng
 description: Kubernetes Node Connectivity Monitor - Next Generation
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"
 keywords:
   - kubernetes
   - connectivity
@@ -22,5 +22,13 @@ annotations:
     - name: Documentation
       url: https://github.com/EsDmitrii/kconmon-ng#readme
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial release
+    - kind: fixed
+      description: MTR lastRun map memory leak — expired entries now purged on each TryAcquire call
+    - kind: fixed
+      description: HTTP body pattern mismatch was silently counted as success in Prometheus metrics
+    - kind: changed
+      description: DNS resolver dial timeout is now configurable via checkers.dns.timeout (default 5s)
+    - kind: changed
+      description: Agent re-registration backoff now includes jitter to prevent thundering herd on controller restart
+    - kind: changed
+      description: MTR traceroute read buffer allocated once per trace instead of per hop

--- a/charts/kconmon-ng/templates/configmap.yaml
+++ b/charts/kconmon-ng/templates/configmap.yaml
@@ -33,6 +33,7 @@ data:
       dns:
         enabled: {{ .Values.config.checkers.dns.enabled }}
         interval: {{ .Values.config.checkers.dns.interval | quote }}
+        timeout: {{ .Values.config.checkers.dns.timeout | quote }}
         hosts:
           {{- range .Values.config.checkers.dns.hosts }}
           - {{ . | quote }}

--- a/charts/kconmon-ng/values.yaml
+++ b/charts/kconmon-ng/values.yaml
@@ -66,6 +66,7 @@ config:
     dns:
       enabled: true
       interval: 5s
+      timeout: 5s
       hosts:
         - kubernetes.default.svc.cluster.local
       resolvers: []

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"os"
 	"regexp"
@@ -88,7 +89,7 @@ func New(cfg *config.Config) (*Agent, error) {
 	}
 	if cfg.Checkers.DNS.Enabled && len(cfg.Checkers.DNS.Hosts) > 0 {
 		sched.AddChecker(
-			checker.NewDNSChecker(cfg.Checkers.DNS.Hosts, cfg.Checkers.DNS.Resolvers),
+			checker.NewDNSChecker(cfg.Checkers.DNS.Hosts, cfg.Checkers.DNS.Resolvers, cfg.Checkers.DNS.Timeout),
 			SchedulerConfig{Interval: cfg.Checkers.DNS.Interval, NodeLocal: true},
 		)
 		slog.Info("checker enabled", "type", "dns", "interval", cfg.Checkers.DNS.Interval)
@@ -202,10 +203,11 @@ func (a *Agent) Run(ctx context.Context) error {
 		wait := 2 * time.Second
 		maxWait := 30 * time.Second
 		for {
+			jitter := time.Duration(rand.Int63n(int64(wait / 4))) //nolint:gosec // G404: non-cryptographic randomness is intentional for backoff jitter
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(wait):
+			case <-time.After(wait + jitter):
 			}
 			newPeers, regErr := grpcClient.Register(ctx, a.info, a.cfg.HTTPPort)
 			if regErr == nil {
@@ -214,7 +216,7 @@ func (a *Agent) Run(ctx context.Context) error {
 				slog.Info("re-registered with controller after reconnect")
 				return
 			}
-			slog.Warn("re-registration failed, retrying", "error", regErr, "backoff", wait)
+			slog.Warn("re-registration failed, retrying", "error", regErr, "backoff", wait+jitter)
 			wait = min(wait*2, maxWait)
 		}
 	}
@@ -316,7 +318,8 @@ func NewResultHandler(m *metrics.PrometheusMetrics, source checker.Target) Resul
 		case model.CheckDNS:
 			if details, ok := result.Details.([]DNSDetails); ok {
 				for _, d := range details {
-					dnsLabels := []string{d.Host, d.Resolver, source.NodeName, source.Zone}
+					dnsLabels := make([]string, 0, 5)
+					dnsLabels = append(dnsLabels, d.Host, d.Resolver, source.NodeName, source.Zone)
 					m.DNSDuration.WithLabelValues(dnsLabels...).Observe(d.Duration.Seconds())
 					r := "success"
 					if len(d.ResolvedIPs) == 0 && !result.Success {
@@ -336,7 +339,7 @@ func NewResultHandler(m *metrics.PrometheusMetrics, source checker.Target) Resul
 					m.HTTPTTFBDuration.WithLabelValues(urlLabels...).Observe(d.TTFBTime.Seconds())
 					m.HTTPTotalDuration.WithLabelValues(urlLabels...).Observe(d.TotalTime.Seconds())
 					r := "success"
-					if d.StatusCode == 0 || d.StatusCode >= 400 {
+					if d.StatusCode == 0 || d.StatusCode >= 400 || d.BodyMismatch {
 						r = "fail"
 					}
 					m.HTTPResults.WithLabelValues(d.URL, d.Method, fmt.Sprintf("%d", d.StatusCode), source.NodeName, source.Zone, r).Inc()

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +14,7 @@ func TestAgentHealthz(t *testing.T) {
 	promReg := prometheus.NewRegistry()
 	srv := NewHTTPServer(promReg)
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/healthz", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)
@@ -27,7 +28,7 @@ func TestAgentReadyzNotReady(t *testing.T) {
 	promReg := prometheus.NewRegistry()
 	srv := NewHTTPServer(promReg)
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)
@@ -42,7 +43,7 @@ func TestAgentReadyzReady(t *testing.T) {
 	srv := NewHTTPServer(promReg)
 	srv.SetReady(true)
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)
@@ -56,7 +57,7 @@ func TestAgentVersion(t *testing.T) {
 	promReg := prometheus.NewRegistry()
 	srv := NewHTTPServer(promReg)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/version", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)
@@ -82,7 +83,7 @@ func TestAgentMetrics(t *testing.T) {
 	promReg := prometheus.NewRegistry()
 	srv := NewHTTPServer(promReg)
 
-	req := httptest.NewRequest(http.MethodGet, "/metrics", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)

--- a/internal/checker/dns.go
+++ b/internal/checker/dns.go
@@ -12,12 +12,14 @@ import (
 type DNSChecker struct {
 	hosts     []string
 	resolvers []string
+	timeout   time.Duration
 }
 
-func NewDNSChecker(hosts, resolvers []string) *DNSChecker {
+func NewDNSChecker(hosts, resolvers []string, timeout time.Duration) *DNSChecker {
 	return &DNSChecker{
 		hosts:     hosts,
 		resolvers: resolvers,
+		timeout:   timeout,
 	}
 }
 
@@ -53,7 +55,7 @@ func (c *DNSChecker) Check(ctx context.Context, _ Target) model.CheckResult {
 			resolver := &net.Resolver{
 				PreferGo: true,
 				Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
-					d := net.Dialer{Timeout: 5 * time.Second}
+					d := net.Dialer{Timeout: c.timeout}
 					return d.DialContext(ctx, "udp", resolverAddr)
 				},
 			}

--- a/internal/checker/dns_test.go
+++ b/internal/checker/dns_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDNSCheckerSuccess(t *testing.T) {
-	c := NewDNSChecker([]string{"localhost"}, nil)
+	c := NewDNSChecker([]string{"localhost"}, nil, 5*time.Second)
 	result := c.Check(context.Background(), Target{})
 
 	if !result.Success {
@@ -24,7 +24,7 @@ func TestDNSCheckerSuccess(t *testing.T) {
 }
 
 func TestDNSCheckerMultipleHosts(t *testing.T) {
-	c := NewDNSChecker([]string{"localhost", "localhost"}, nil)
+	c := NewDNSChecker([]string{"localhost", "localhost"}, nil, 5*time.Second)
 	result := c.Check(context.Background(), Target{})
 
 	if !result.Success {
@@ -41,7 +41,7 @@ func TestDNSCheckerMultipleHosts(t *testing.T) {
 }
 
 func TestDNSCheckerUnresolvable(t *testing.T) {
-	c := NewDNSChecker([]string{"this.host.definitely.does.not.exist.invalid"}, nil)
+	c := NewDNSChecker([]string{"this.host.definitely.does.not.exist.invalid"}, nil, 5*time.Second)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -57,10 +57,18 @@ func TestDNSCheckerUnresolvable(t *testing.T) {
 }
 
 func TestDNSCheckerEmptyHosts(t *testing.T) {
-	c := NewDNSChecker(nil, nil)
+	c := NewDNSChecker(nil, nil, 5*time.Second)
 	result := c.Check(context.Background(), Target{})
 
 	if !result.Success {
 		t.Error("expected success for empty hosts list")
+	}
+}
+
+func TestDNSCheckerTimeoutPropagated(t *testing.T) {
+	const customTimeout = 3 * time.Second
+	c := NewDNSChecker([]string{"localhost"}, nil, customTimeout)
+	if c.timeout != customTimeout {
+		t.Errorf("expected timeout %v, got %v", customTimeout, c.timeout)
 	}
 }

--- a/internal/checker/http.go
+++ b/internal/checker/http.go
@@ -63,6 +63,9 @@ func (c *HTTPChecker) Check(ctx context.Context, _ Target) model.CheckResult {
 		if detail.StatusCode == 0 && firstErr == "" {
 			firstErr = fmt.Sprintf("HTTP check %s failed", target.URL)
 		}
+		if detail.BodyMismatch && firstErr == "" {
+			firstErr = fmt.Sprintf("HTTP check %s: body pattern mismatch", target.URL)
+		}
 	}
 
 	if firstErr != "" {
@@ -148,7 +151,7 @@ func (c *HTTPChecker) checkOne(ctx context.Context, target HTTPCheckTarget) mode
 	if target.BodyPattern != nil {
 		body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit
 		if err == nil && !target.BodyPattern.Match(body) {
-			detail.StatusCode = -1
+			detail.BodyMismatch = true
 		}
 	} else {
 		_, _ = io.Copy(io.Discard, resp.Body)

--- a/internal/checker/http_test.go
+++ b/internal/checker/http_test.go
@@ -63,12 +63,45 @@ func TestHTTPCheckerBodyPatternMismatch(t *testing.T) {
 
 	result := c.Check(context.Background(), Target{})
 
+	if result.Success {
+		t.Error("expected failure for body pattern mismatch")
+	}
+
 	details, ok := result.Details.([]model.HTTPDetails)
 	if !ok || len(details) == 0 {
 		t.Fatal("expected HTTPDetails")
 	}
-	if details[0].StatusCode != -1 {
-		t.Errorf("expected status -1 for body mismatch, got %d", details[0].StatusCode)
+	if !details[0].BodyMismatch {
+		t.Error("expected BodyMismatch=true for mismatched body pattern")
+	}
+	if details[0].StatusCode != http.StatusOK {
+		t.Errorf("expected real HTTP status 200, got %d", details[0].StatusCode)
+	}
+}
+
+func TestHTTPCheckerBodyPatternMatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPChecker(5*time.Second, []HTTPCheckTarget{
+		{URL: srv.URL, Method: "GET", BodyPattern: regexp.MustCompile(`"status":"ok"`)},
+	})
+
+	result := c.Check(context.Background(), Target{})
+
+	if !result.Success {
+		t.Errorf("expected success for matching body pattern, got error: %s", result.Error)
+	}
+
+	details, ok := result.Details.([]model.HTTPDetails)
+	if !ok || len(details) == 0 {
+		t.Fatal("expected HTTPDetails")
+	}
+	if details[0].BodyMismatch {
+		t.Error("expected BodyMismatch=false for matching body pattern")
 	}
 }
 

--- a/internal/checker/mtr.go
+++ b/internal/checker/mtr.go
@@ -40,6 +40,8 @@ func (c *MTRChecker) Name() model.CheckType {
 // TryAcquire checks whether MTR can run for the given source-destination pair
 // and, if so, atomically records the current time to enforce the cooldown.
 // Returns true if the trace should proceed, false if still within cooldown.
+// Expired entries are purged on each call to prevent unbounded map growth in
+// large clusters where node pairs come and go over time.
 func (c *MTRChecker) TryAcquire(source, destination string) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -48,6 +50,13 @@ func (c *MTRChecker) TryAcquire(source, destination string) bool {
 	if last, ok := c.lastRun[key]; ok && time.Since(last) < c.cooldown {
 		return false
 	}
+
+	for k, t := range c.lastRun {
+		if time.Since(t) >= c.cooldown {
+			delete(c.lastRun, k)
+		}
+	}
+
 	c.lastRun[key] = time.Now()
 	return true
 }
@@ -116,6 +125,7 @@ func (c *MTRChecker) traceroute(ctx context.Context, dst net.IP) ([]model.MTRHop
 
 	id := os.Getpid() & 0xffff
 	hops := make([]model.MTRHop, 0, c.maxHops)
+	buf := make([]byte, 1500)
 
 	for ttl := 1; ttl <= c.maxHops; ttl++ {
 		select {
@@ -157,7 +167,6 @@ func (c *MTRChecker) traceroute(ctx context.Context, dst net.IP) ([]model.MTRHop
 		if deadlineErr := conn.SetReadDeadline(time.Now().Add(c.timeout)); deadlineErr != nil {
 			continue
 		}
-		buf := make([]byte, 1500)
 		n, peer, err := conn.ReadFrom(buf)
 		rtt := time.Since(start)
 

--- a/internal/checker/mtr_test.go
+++ b/internal/checker/mtr_test.go
@@ -1,6 +1,7 @@
 package checker
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -52,5 +53,31 @@ func TestMTRCheckerTryAcquireAtomicRecord(t *testing.T) {
 
 	if !recorded {
 		t.Error("TryAcquire must record the key atomically")
+	}
+}
+
+func TestMTRCheckerExpiredEntriesPurged(t *testing.T) {
+	c := NewMTRChecker(30, 1*time.Second, 100*time.Millisecond)
+
+	// Seed several expired entries directly.
+	c.mu.Lock()
+	for i := range 5 {
+		key := fmt.Sprintf("node-%d->node-x", i)
+		c.lastRun[key] = time.Now().Add(-200 * time.Millisecond)
+	}
+	c.mu.Unlock()
+
+	// TryAcquire for a new pair triggers cleanup of the expired entries.
+	if !c.TryAcquire("node-new", "node-x") {
+		t.Fatal("expected TryAcquire=true for new pair")
+	}
+
+	c.mu.Lock()
+	remaining := len(c.lastRun)
+	c.mu.Unlock()
+
+	// Only the newly recorded entry should remain.
+	if remaining != 1 {
+		t.Errorf("expected 1 entry after purge, got %d", remaining)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ type ICMPCheckerConfig struct {
 type DNSCheckerConfig struct {
 	Enabled   bool          `yaml:"enabled"`
 	Interval  time.Duration `yaml:"interval"`
+	Timeout   time.Duration `yaml:"timeout"`
 	Hosts     []string      `yaml:"hosts"`
 	Resolvers []string      `yaml:"resolvers,omitempty"`
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -31,6 +31,7 @@ func DefaultConfig() *Config {
 			DNS: DNSCheckerConfig{
 				Enabled:  true,
 				Interval: 5 * time.Second,
+				Timeout:  5 * time.Second,
 				Hosts:    []string{"kubernetes.default.svc.cluster.local"},
 			},
 			HTTP: HTTPCheckerConfig{

--- a/internal/controller/server_test.go
+++ b/internal/controller/server_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +17,7 @@ func TestHealthzEndpoint(t *testing.T) {
 	promReg := prometheus.NewRegistry()
 	srv := NewHTTPServer(reg, nil, promReg)
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/healthz", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)
@@ -34,7 +35,7 @@ func TestReadyzEndpointNotReady(t *testing.T) {
 	promReg := prometheus.NewRegistry()
 	srv := NewHTTPServer(reg, nil, promReg)
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)
@@ -50,7 +51,7 @@ func TestReadyzEndpointReady(t *testing.T) {
 	srv := NewHTTPServer(reg, nil, promReg)
 	srv.SetReady(true)
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)
@@ -65,7 +66,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	promReg := prometheus.NewRegistry()
 	srv := NewHTTPServer(reg, nil, promReg)
 
-	req := httptest.NewRequest(http.MethodGet, "/metrics", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)
@@ -83,7 +84,7 @@ func TestTopologyEndpoint(t *testing.T) {
 	promReg := prometheus.NewRegistry()
 	srv := NewHTTPServer(reg, nil, promReg)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/topology", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/topology", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)
@@ -117,7 +118,7 @@ func TestTopologyEndpointWithNodeWatcher(t *testing.T) {
 	}
 	srv.SetNodeWatcher(nw)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/topology", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/topology", http.NoBody)
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 
@@ -140,7 +141,7 @@ func TestVersionEndpoint(t *testing.T) {
 	promReg := prometheus.NewRegistry()
 	srv := NewHTTPServer(reg, nil, promReg)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", http.NoBody)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/version", http.NoBody)
 	w := httptest.NewRecorder()
 
 	srv.Handler().ServeHTTP(w, req)

--- a/internal/model/result.go
+++ b/internal/model/result.go
@@ -56,14 +56,15 @@ type DNSDetails struct {
 }
 
 type HTTPDetails struct {
-	URL         string        `json:"url"`
-	Method      string        `json:"method"`
-	StatusCode  int           `json:"statusCode"`
-	DNSTime     time.Duration `json:"dnsTime"`
-	ConnectTime time.Duration `json:"connectTime"`
-	TLSTime     time.Duration `json:"tlsTime"`
-	TTFBTime    time.Duration `json:"ttfbTime"`
-	TotalTime   time.Duration `json:"totalTime"`
+	URL          string        `json:"url"`
+	Method       string        `json:"method"`
+	StatusCode   int           `json:"statusCode"`
+	BodyMismatch bool          `json:"bodyMismatch,omitempty"`
+	DNSTime      time.Duration `json:"dnsTime"`
+	ConnectTime  time.Duration `json:"connectTime"`
+	TLSTime      time.Duration `json:"tlsTime"`
+	TTFBTime     time.Duration `json:"ttfbTime"`
+	TotalTime    time.Duration `json:"totalTime"`
 }
 
 type MTRHop struct {


### PR DESCRIPTION
…eout

Bug fixes:
- MTR lastRun map grew unboundedly; expired entries are now purged inline on each TryAcquire call while the lock is held
- HTTP body pattern mismatch was silently recorded as result="success" in Prometheus due to StatusCode=-1 not matching the >=400 guard; replaced with a dedicated BodyMismatch bool field in HTTPDetails, result handler now correctly labels these checks as result="fail"

Improvements:
- DNS resolver dial timeout was hard-coded to 5s; added configurable timeout field to DNSCheckerConfig (default: 5s)
- Agent re-registration backoff now adds up to 25% random jitter per retry to prevent thundering herd when the controller restarts
- MTR read buffer (1500B) moved outside the hop loop to avoid per-hop allocation

Helm chart:
- Bumped chart and appVersion to 1.1.0
- Added checkers.dns.timeout to values.yaml and configmap template
- Updated artifacthub.io/changes annotation

Tests:
- TestMTRCheckerExpiredEntriesPurged: verifies stale map entries are cleaned up
- TestDNSCheckerTimeoutPropagated: verifies timeout is stored on checker
- TestHTTPCheckerBodyPatternMismatch: updated to check BodyMismatch field
- TestHTTPCheckerBodyPatternMatch: new test for successful pattern match

## Summary

<!-- What does this PR do? Why? -->

## Changes

-

## Checklist

- [ ] `go test ./...` passes
- [ ] `golangci-lint run` passes
- [ ] `helm lint charts/kconmon-ng` passes
- [ ] New/changed metrics are documented in README
- [ ] Dashboards updated if metrics changed
