### PR TITLE
fix(chart): open net.ipv4.ping_group_range for the ICMP checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ for the controller's node watch.
 
 ```bash
 helm upgrade --install kconmon-ng oci://ghcr.io/esdmitrii/charts/kconmon-ng \
-  --version 1.3.2 \
+  --version 1.3.3 \
   --set serviceMonitor.enabled=true \
   --set prometheusRule.enabled=true
 ```
@@ -164,7 +164,7 @@ lands in the official krew index):
 
 ```bash
 kubectl krew install --manifest-url \
-  https://github.com/EsDmitrii/kconmon-ng/releases/download/v1.3.2/kconmon.yaml
+  https://github.com/EsDmitrii/kconmon-ng/releases/download/v1.3.3/kconmon.yaml
 ```
 
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,9 @@
   (defaults to opening `ping_group_range` for the ICMP checker). Set
   `agent.podSecurityContext: {}` to opt out. Documented in the chart README and
   `values.schema.json`.
+- `values.schema.json`: HTTP target field corrected from `expectedStatus` to
+  `expectStatus` to match the checker's config (the schema key never matched the
+  code, so a schema-guided value was silently ignored).
 
 ### Install
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,51 @@
+## kconmon-ng v1.3.3
+
+> Chart-focused release. The Go agent/controller code is unchanged from v1.3.2;
+> the `:1.3.3` images are a version-synchronized rebuild (the release tag drives
+> both the chart version and the image tag).
+
+### Fixes
+
+- **ICMP checker on runtimes with a closed `net.ipv4.ping_group_range`** — the ICMP
+  checker opens an unprivileged ICMP "ping" socket (`SOCK_DGRAM`), which the kernel
+  gates on `net.ipv4.ping_group_range`, not on `NET_RAW`. Some container runtimes
+  leave this at the closed kernel default (`1 0`), so the checker failed with
+  `socket: permission denied` on those nodes. The agent Pod now sets the safe,
+  namespaced sysctl `net.ipv4.ping_group_range=0 2147483647`, so ping sockets work
+  regardless of the runtime default.
+
+### Chart
+
+- New `agent.podSecurityContext` value exposes the agent Pod-level `securityContext`
+  (defaults to opening `ping_group_range` for the ICMP checker). Set
+  `agent.podSecurityContext: {}` to opt out. Documented in the chart README and
+  `values.schema.json`.
+
+### Install
+
+```bash
+helm upgrade --install kconmon-ng oci://ghcr.io/esdmitrii/charts/kconmon-ng \
+  --version 1.3.3 \
+  --namespace kconmon-ng \
+  --create-namespace
+```
+
+kubectl plugin (via krew, from the release manifest):
+
+```bash
+kubectl krew install --manifest-url \
+  https://github.com/EsDmitrii/kconmon-ng/releases/download/v1.3.3/kconmon.yaml
+```
+
+### Images
+
+```
+ghcr.io/esdmitrii/kconmon-ng-agent:1.3.3
+ghcr.io/esdmitrii/kconmon-ng-controller:1.3.3
+```
+
+---
+
 ## kconmon-ng v1.3.2
 
 > Note: this is the first fully working release of the on-demand diagnostics

--- a/charts/kconmon-ng/Chart.yaml
+++ b/charts/kconmon-ng/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: kconmon-ng
 description: Kubernetes Node Connectivity Monitor - Next Generation
 type: application
-version: 1.3.2
-appVersion: "1.3.2"
+version: 1.3.3
+appVersion: "1.3.3"
 keywords:
   - kubernetes
   - connectivity
@@ -25,6 +25,10 @@ annotations:
     - name: Documentation
       url: https://github.com/EsDmitrii/kconmon-ng#readme
   artifacthub.io/changes: |
+    - kind: fixed
+      description: ICMP checker sets net.ipv4.ping_group_range so ping sockets work on all runtimes
+    - kind: added
+      description: new agent.podSecurityContext value opens net.ipv4.ping_group_range for the ICMP checker
     - kind: added
       description: kubectl-kconmon plugin for on-demand topology and connectivity checks (install via krew)
     - kind: added

--- a/charts/kconmon-ng/Chart.yaml
+++ b/charts/kconmon-ng/Chart.yaml
@@ -29,6 +29,8 @@ annotations:
       description: ICMP checker sets net.ipv4.ping_group_range so ping sockets work on all runtimes
     - kind: added
       description: new agent.podSecurityContext value opens net.ipv4.ping_group_range for the ICMP checker
+    - kind: fixed
+      description: values.schema.json http target field expectedStatus -> expectStatus to match the checker
     - kind: added
       description: kubectl-kconmon plugin for on-demand topology and connectivity checks (install via krew)
     - kind: added

--- a/charts/kconmon-ng/README.md
+++ b/charts/kconmon-ng/README.md
@@ -15,27 +15,31 @@ results as Prometheus metrics.
   `PrometheusRule` resources (`serviceMonitor.enabled` / `prometheusRule.enabled`)
 - The agent Pods request the `NET_RAW` capability (for ICMP / raw sockets used by
   the ICMP checker and MTR)
+- The ICMP checker opens an unprivileged ICMP "ping" socket, which the kernel
+  gates on `net.ipv4.ping_group_range`. Some container runtimes leave this at the
+  closed default (`1 0`), so the chart sets the (safe) sysctl via
+  `agent.podSecurityContext`. Set `agent.podSecurityContext: {}` to opt out.
 
 ## Installing
 
 The chart is published as an OCI artifact on GHCR.
 
 ```bash
-helm install kconmon-ng oci://ghcr.io/esdmitrii/charts/kconmon-ng --version 1.3.2
+helm install kconmon-ng oci://ghcr.io/esdmitrii/charts/kconmon-ng --version 1.3.3
 ```
 
 With custom values:
 
 ```bash
 helm install kconmon-ng oci://ghcr.io/esdmitrii/charts/kconmon-ng \
-  --version 1.3.2 -f values.yaml
+  --version 1.3.3 -f values.yaml
 ```
 
 ### Upgrading
 
 ```bash
 helm upgrade kconmon-ng oci://ghcr.io/esdmitrii/charts/kconmon-ng \
-  --version 1.3.2 -f values.yaml
+  --version 1.3.3 -f values.yaml
 ```
 
 ### Uninstalling
@@ -56,6 +60,8 @@ The table below lists the most relevant parameters. See
 | `controller.resources` | requests `50m`/`64Mi`, limits `200m`/`128Mi` | Controller resource requests/limits |
 | `agent.tolerations` | `[{operator: Exists}]` | Agent DaemonSet tolerations (default: run on all nodes) |
 | `agent.resources` | requests `50m`/`64Mi`, limits `200m`/`128Mi` | Agent resource requests/limits |
+| `agent.securityContext` | `{capabilities: {add: [NET_RAW]}}` | Agent container securityContext (NET_RAW for ICMP/MTR raw sockets) |
+| `agent.podSecurityContext` | `{sysctls: [{name: net.ipv4.ping_group_range, value: "0 2147483647"}]}` | Agent Pod securityContext; opens `ping_group_range` so the ICMP checker can open ping sockets. Set to `{}` to opt out |
 | `config.metricsPrefix` | `kconmon_ng` | Prefix for all exported Prometheus metrics |
 | `config.checkers.tcp.enabled` | `true` | Enable TCP checker (interval `5s`, timeout `1s`) |
 | `config.checkers.udp.enabled` | `true` | Enable UDP checker (interval `5s`, timeout `250ms`, `packets: 5`) |

--- a/charts/kconmon-ng/templates/agent/daemonset.yaml
+++ b/charts/kconmon-ng/templates/agent/daemonset.yaml
@@ -51,6 +51,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.agent.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: agent
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"

--- a/charts/kconmon-ng/values.schema.json
+++ b/charts/kconmon-ng/values.schema.json
@@ -102,7 +102,7 @@
                     "properties": {
                       "url": { "type": "string", "format": "uri" },
                       "method": { "type": "string", "enum": ["GET", "HEAD"] },
-                      "expectedStatus": { "type": "integer" },
+                      "expectStatus": { "type": "integer" },
                       "bodyPattern": { "type": "string" }
                     }
                   }

--- a/charts/kconmon-ng/values.schema.json
+++ b/charts/kconmon-ng/values.schema.json
@@ -36,7 +36,8 @@
         },
         "resources": { "type": "object" },
         "tolerations": { "type": "array" },
-        "securityContext": { "type": "object" }
+        "securityContext": { "type": "object" },
+        "podSecurityContext": { "type": "object" }
       }
     },
     "config": {

--- a/charts/kconmon-ng/values.yaml
+++ b/charts/kconmon-ng/values.yaml
@@ -69,6 +69,16 @@ agent:
     capabilities:
       add:
         - NET_RAW
+  # Pod-level security context. The ICMP checker opens an unprivileged ICMP
+  # "ping" socket (SOCK_DGRAM+IPPROTO_ICMP), which the kernel gates on
+  # net.ipv4.ping_group_range — NOT on NET_RAW. Some container runtimes leave
+  # this at the closed kernel default ("1 0"), so the checker fails with
+  # "socket: permission denied". Opening the range (a safe, namespaced sysctl)
+  # lets any GID create ping sockets. Set podSecurityContext to {} to opt out.
+  podSecurityContext:
+    sysctls:
+      - name: net.ipv4.ping_group_range
+        value: "0 2147483647"
 
 # Runtime configuration rendered into a ConfigMap and consumed by both the
 # controller and the agents. Changes are hot-reloaded without a restart.


### PR DESCRIPTION
The ICMP checker opens an unprivileged ping socket (SOCK_DGRAM) gated by
net.ipv4.ping_group_range, not NET_RAW. Runtimes that leave it at the closed
kernel default (1 0) fail with 'socket: permission denied'. Set the safe,
namespaced sysctl via a new agent.podSecurityContext value. Chart 1.3.2 -> 1.3.3
